### PR TITLE
Separate username/password from oauth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ Configuration Properties
 | Property name | Purpose | Example value |
 | ------------- | ------- | ------------- |
 | config.repo.remote | github repo URI | https://github.com/opentable/service-ot-frontdoor-config |
-| config.repo.username | username or API key | *your github API key* |
-| config.repo.password | password or authentication method | x-oauth-basic |
+| config.repo.oauth-token | github oauth token |
+| config.repo.username | username | *your username* |
+| config.repo.password | password | *your password* |
 | config.repo.local | where to check out repo locally (URI) | frontdoor-config |
 | config.repo.branch | The branch in the configuration repo to read | master |
 | config.repo.file | The configuraation file to read (relative to repo) | /mappings.cfg.tsv |
+
+**Note**: `config.repo.oauth-token` and `config.repo.username/password` are mutually exclusive.
+You should use one or the other, but not both. (Setting an `oauth-token` automatically sets your
+password to `"x-oauth-basic"`.)

--- a/src/main/java/com/opentable/versionedconfig/GitOperations.java
+++ b/src/main/java/com/opentable/versionedconfig/GitOperations.java
@@ -1,5 +1,7 @@
 package com.opentable.versionedconfig;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -46,10 +48,13 @@ final class GitOperations {
     }
 
     private Optional<CredentialsProvider> makeCredentials(String username, String password) {
-        if (username == null && password == null) {
+        boolean missingUsername = isNullOrEmpty(username);
+        boolean missingPassword = isNullOrEmpty(password);
+
+        if (missingUsername && missingPassword) {
             return Optional.empty();
-        } else if (username == null || password == null) {
-            throw new IllegalArgumentException("must provide username and password, or both must be null");
+        } else if (missingUsername || missingPassword) {
+            throw new IllegalArgumentException("must provide username and password, or both must be empty/null");
         }
         return Optional.of(new UsernamePasswordCredentialsProvider(username, password));
     }

--- a/src/main/java/com/opentable/versionedconfig/GitProperties.java
+++ b/src/main/java/com/opentable/versionedconfig/GitProperties.java
@@ -18,8 +18,8 @@ public class GitProperties {
     private final String branch;
 
     public GitProperties(URI remoteRepository,
-                         String username,
-                         String password,
+                         @Nullable String username,
+                         @Nullable String password,
                          @Nullable File localRepository,
                          String branch) {
         this.remoteRepository = remoteRepository;

--- a/src/main/java/com/opentable/versionedconfig/VersionedConfig.java
+++ b/src/main/java/com/opentable/versionedconfig/VersionedConfig.java
@@ -1,5 +1,7 @@
 package com.opentable.versionedconfig;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import java.io.File;
 import java.net.URI;
 
@@ -11,13 +13,24 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class VersionedConfig {
+    static final String X_OAUTH_BASIC = "x-oauth-basic";
+
     @Bean
     public GitProperties defaultVersioningServiceProperties(@Value("${config.repo.remote}") URI remoteRepo,
-                                                            @Value("${config.repo.username}") String username,
-                                                            @Value("${config.repo.password:x-oauth-basic}") String auth,
+                                                            @Value("${config.repo.oauth-token:#{null}}") String token,
+                                                            @Value("${config.repo.username:#{null}}") String username,
+                                                            @Value("${config.repo.password:#{null}}") String password,
                                                             @Value("${config.repo.local:#{null}}") File localPath,
                                                             @Value("${config.repo.branch:master}") String branch) {
-        return new GitProperties(remoteRepo, username, auth, localPath, branch);
+        if (!isNullOrEmpty(token)) {
+            if (!(isNullOrEmpty(username) && isNullOrEmpty(password))) {
+                throw new IllegalArgumentException("oauth-token and username/password are mutually exclusive");
+            }
+            username = token;
+            password = X_OAUTH_BASIC;
+        }
+
+        return new GitProperties(remoteRepo, username, password, localPath, branch);
     }
 
     @Bean

--- a/src/test/java/com/opentable/versionedconfig/GitServiceTest.java
+++ b/src/test/java/com/opentable/versionedconfig/GitServiceTest.java
@@ -1,6 +1,7 @@
 package com.opentable.versionedconfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.File;
 import java.io.IOException;
@@ -105,6 +106,19 @@ public class GitServiceTest {
         final VersioningService service = VersioningService.forGitRepository(gitProperties);
         assertThat(service.getBranch()).isEqualTo(gitProperties.getBranch());
         assertThat(service.getRemoteRepository()).isEqualTo(gitProperties.getRemoteRepository());
+    }
+
+    @Test
+    public void testCredentialsMustBothBeEmptyOrNull() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> VersioningService.forGitRepository(
+                        new GitProperties(null, "username", null, null, "master")))
+                .withMessageContaining("must provide username and password");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> VersioningService.forGitRepository(
+                        new GitProperties(null, null, "password", null, "master")))
+                .withMessageContaining("must provide username and password");
     }
 
     private GitProperties getGitProperties(File checkoutSpot) {

--- a/src/test/java/com/opentable/versionedconfig/VersionedConfigTest.java
+++ b/src/test/java/com/opentable/versionedconfig/VersionedConfigTest.java
@@ -1,0 +1,31 @@
+package com.opentable.versionedconfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.Test;
+
+public class VersionedConfigTest {
+    private final VersionedConfig config = new VersionedConfig();
+
+    @Test
+    public void testOauthToken() {
+        GitProperties props = config.defaultVersioningServiceProperties(null, "1234", null, null, null, "master");
+        assertThat(props.getUsername()).isEqualTo("1234");
+        assertThat(props.getPassword()).isEqualTo(VersionedConfig.X_OAUTH_BASIC);
+    }
+
+    @Test
+    public void testUsernamePassword() {
+        GitProperties props = config.defaultVersioningServiceProperties(null, null, "foo", "bar", null, "master");
+        assertThat(props.getUsername()).isEqualTo("foo");
+        assertThat(props.getPassword()).isEqualTo("bar");
+    }
+
+    @Test
+    public void testConflictingCredentials() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> config.defaultVersioningServiceProperties(null, "1234", "foo", "bar", null, "master"))
+                .withMessageContaining("oauth-token and username/password are mutually exclusive");
+    }
+}


### PR DESCRIPTION
* New oauth-token config setting (with docs)
* Username and password handled separately from tokens
* All three now default to null
* Nulls and empty strings are handled the same way

![](http://tclhost.com/pdCvxp7.gif)