### PR TITLE
Improve commit formatting

### DIFF
--- a/src/main/java/com/opentable/versionedconfig/GitService.java
+++ b/src/main/java/com/opentable/versionedconfig/GitService.java
@@ -75,7 +75,7 @@ class GitService implements VersioningService {
     @Override
     public VersionedConfigUpdate getCurrentState() {
         return new VersionedConfigUpdate(
-                checkoutDirectory, Stream.empty(), null, latestKnownObjectId.toString());
+                checkoutDirectory, Stream.empty(), null, latestKnownObjectId.get());
     }
 
     /**
@@ -112,7 +112,7 @@ class GitService implements VersioningService {
         LOG.info("Update {} is relevant to my interests", pulled);
         latestKnownObjectId.set(pulled);
         return Optional.of(new VersionedConfigUpdate(
-                checkoutDirectory, affectedPaths, current.toString(), pulled.toString()));
+                checkoutDirectory, affectedPaths, current, pulled));
     }
 
     @Override

--- a/src/main/java/com/opentable/versionedconfig/VersionedConfigUpdate.java
+++ b/src/main/java/com/opentable/versionedconfig/VersionedConfigUpdate.java
@@ -8,6 +8,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.eclipse.jgit.lib.ObjectId;
+
 /**
  * Carries around info about files touched by git updates.
  */
@@ -25,9 +27,10 @@ public final class VersionedConfigUpdate {
     /**
      * Description of the VCS revisions that this change describes (e.g. SHA for git).
      */
-    private final String oldRevision, newRevision;
+    private final ObjectId oldRevision;
+    private final ObjectId newRevision;
 
-    public VersionedConfigUpdate(Path basePath, Stream<Path> changedFiles, String oldRevision, String newRevision) {
+    public VersionedConfigUpdate(Path basePath, Stream<Path> changedFiles, ObjectId oldRevision, ObjectId newRevision) {
         this.basePath = basePath;
         this.changedFiles = changedFiles;
         this.oldRevision = oldRevision;
@@ -59,15 +62,29 @@ public final class VersionedConfigUpdate {
      * @return the start revision for this diff
      */
     @Nullable
-    public String getOldRevision() {
+    public ObjectId getOldRevisionMetadata() {
         return oldRevision;
+    }
+
+    /**
+     * @return the start revision name for this diff
+     */
+    public String getOldRevision() {
+        return oldRevision == null ? "<unknown>" : oldRevision.getName();
     }
 
     /**
      * @return the end revision for this diff
      */
     @Nonnull
-    public String getNewRevision() {
+    public ObjectId getNewRevisionMetadata() {
         return newRevision;
+    }
+
+    /**
+     * @return the end revision name for this diff
+     */
+    public String getNewRevision() {
+        return newRevision == null ? "<unknown>" : newRevision.getName();
     }
 }


### PR DESCRIPTION
Currently, commit objects (`ObjectId`) coming from this library are
rendered like this:

```
commit e1c27dd5907598e193607fff53e978bdc5770fda 1500920208 ----sp
```

This is an internal representation of the RevCommit object by jgit which
represents the object type, object id, object timestamp, and object
flags (`-` means unset, `s` means "SEEN" and `p` means "PARSED"). This
change makes the `getNewRevision` and `getOldRevision` methods return
just the commit hash ("e1c27" etc) without the additional jgit metadata.
It also exposes the `ObjectId` directly through the related metadata
methods in case those are useful to the end user.

![](http://ljdchost.com/I4ri4wP.gif)