### PR TITLE
set timeout on pull command

### DIFF
--- a/src/main/java/com/opentable/versionedconfig/GitOperations.java
+++ b/src/main/java/com/opentable/versionedconfig/GitOperations.java
@@ -66,10 +66,10 @@ final class GitOperations {
             op.setCredentialsProvider(new UsernamePasswordCredentialsProvider(StringUtils.substringBefore(ui, ":"), StringUtils.substringAfter(ui, ":")));
         }
 
-        int duration = config.getDuration();
-        if (duration != -1){
-            op.setTimeout(duration);
-            LOG.trace("set duration: {}", duration);
+        int durations = config.getDurations();
+        if (durations > 0){
+            op.setTimeout(durations);
+            LOG.trace("set durations: {}", durations);
         }
     }
 

--- a/src/main/java/com/opentable/versionedconfig/GitOperations.java
+++ b/src/main/java/com/opentable/versionedconfig/GitOperations.java
@@ -108,11 +108,17 @@ final class GitOperations {
         LOG.trace("pulling latest");
         return upstreamRetry(remoteIndex -> {
             try {
+                int timeout = config.getTimeoutInSec();
                 final PullCommand pull = git.pull();
                 LOG.trace("Git pull completed");
                 configureCredentials(pull, config.getRemoteRepositories().get(remoteIndex));
                 LOG.trace("Configuration of credentials completed, setting remote {}", remoteIndex);
                 pull.setRemote("remote" + remoteIndex);
+
+                //set timeout if defined
+                if (timeout != -1){
+                    pull.setTimeout(timeout);
+                }
                 // Added but not deployed yet
                 pull.setProgressMonitor(LOGGING_PROGRESS_MONITOR);
                 PullResult result = pull.call();

--- a/src/main/java/com/opentable/versionedconfig/GitOperations.java
+++ b/src/main/java/com/opentable/versionedconfig/GitOperations.java
@@ -79,12 +79,18 @@ final class GitOperations {
             LOG.info("cloning {} (branch {}) to {}", remoteIndex, cloneBranch, checkoutDir);
 
             try {
+                int duration = config.getDuration();
                 final URI uri = remotes.get(remoteIndex);
                 CloneCommand clone = Git.cloneRepository()
                         .setBare(false)
                         .setBranch(cloneBranch)
                         .setDirectory(checkoutDir.toFile())
                         .setURI(uri.toString());
+
+                if (duration != -1){
+                    clone.setTimeout(duration);
+                }
+                
                 configureCredentials(clone, uri);
                 return clone.call();
             } catch (GitAPIException ioe) {
@@ -108,7 +114,7 @@ final class GitOperations {
         LOG.trace("pulling latest");
         return upstreamRetry(remoteIndex -> {
             try {
-                int timeout = config.getTimeoutInSec();
+                int duration = config.getDuration();
                 final PullCommand pull = git.pull();
                 LOG.trace("Git pull completed");
                 configureCredentials(pull, config.getRemoteRepositories().get(remoteIndex));
@@ -116,8 +122,8 @@ final class GitOperations {
                 pull.setRemote("remote" + remoteIndex);
 
                 //set timeout if defined
-                if (timeout != -1){
-                    pull.setTimeout(timeout);
+                if (duration != -1){
+                    pull.setTimeout(duration);
                 }
                 // Added but not deployed yet
                 pull.setProgressMonitor(LOGGING_PROGRESS_MONITOR);

--- a/src/main/java/com/opentable/versionedconfig/GitProperties.java
+++ b/src/main/java/com/opentable/versionedconfig/GitProperties.java
@@ -31,7 +31,7 @@ public class GitProperties {
     private final Path localRepository;
     private final String branch;
 
-    private final int duration;
+    private final int durations;
 
     public GitProperties(URI remoteRepository,
                          @Nullable Path localRepository,
@@ -45,7 +45,7 @@ public class GitProperties {
         this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
         this.localRepository = localRepository;
         this.branch = branch;
-        this.duration = -1;
+        this.durations = -1;
     }
 
     /*
@@ -60,7 +60,7 @@ public class GitProperties {
         this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
         this.localRepository = localRepository;
         this.branch = branch;
-        this.duration = duration;
+        this.durations = duration;
     }
 
     public List<URI> getRemoteRepositories() {
@@ -75,7 +75,7 @@ public class GitProperties {
         return branch;
     }
 
-    public int getDuration() { return duration; }
+    public int getDurations() { return durations; }
 
     @Override
     public boolean equals(Object o) {
@@ -90,12 +90,12 @@ public class GitProperties {
         return Objects.equal(remoteRepositories, that.remoteRepositories) &&
                 Objects.equal(localRepository, that.localRepository) &&
                 Objects.equal(branch, that.branch) &&
-                Objects.equal(duration, that.duration);
+                Objects.equal(durations, that.durations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(remoteRepositories, localRepository, branch, duration);
+        return Objects.hashCode(remoteRepositories, localRepository, branch, durations);
     }
 
     @Override
@@ -104,7 +104,7 @@ public class GitProperties {
                 "remoteRepositories=" + remoteRepositories +
                 ", localRepository=" + localRepository +
                 ", branch='" + branch + '\'' +
-                ", duration=" + duration +
+                ", durations=" + durations +
                 '}';
     }
 }

--- a/src/main/java/com/opentable/versionedconfig/GitProperties.java
+++ b/src/main/java/com/opentable/versionedconfig/GitProperties.java
@@ -31,6 +31,8 @@ public class GitProperties {
     private final Path localRepository;
     private final String branch;
 
+    private final int timeoutInSec;
+
     public GitProperties(URI remoteRepository,
                          @Nullable Path localRepository,
                          String branch) {
@@ -43,6 +45,17 @@ public class GitProperties {
         this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
         this.localRepository = localRepository;
         this.branch = branch;
+        this.timeoutInSec = -1;
+    }
+
+    public GitProperties(List<URI> remoteRepositories,
+                         @Nullable Path localRepository,
+                         String branch,
+                         int timeoutInSec){
+        this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
+        this.localRepository = localRepository;
+        this.branch = branch;
+        this.timeoutInSec = timeoutInSec;
     }
 
     public List<URI> getRemoteRepositories() {
@@ -57,6 +70,8 @@ public class GitProperties {
         return branch;
     }
 
+    public int getTimeoutInSec() { return timeoutInSec; }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -69,12 +84,13 @@ public class GitProperties {
         GitProperties that = (GitProperties) o;
         return Objects.equal(remoteRepositories, that.remoteRepositories) &&
                 Objects.equal(localRepository, that.localRepository) &&
-                Objects.equal(branch, that.branch);
+                Objects.equal(branch, that.branch) &&
+                Objects.equal(timeoutInSec, that.timeoutInSec);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(remoteRepositories, localRepository, branch);
+        return Objects.hashCode(remoteRepositories, localRepository, branch, timeoutInSec);
     }
 
     @Override
@@ -83,6 +99,7 @@ public class GitProperties {
                 "remoteRepositories=" + remoteRepositories +
                 ", localRepository=" + localRepository +
                 ", branch='" + branch + '\'' +
+                ", timeoutInSec=" + timeoutInSec +
                 '}';
     }
 }

--- a/src/main/java/com/opentable/versionedconfig/GitProperties.java
+++ b/src/main/java/com/opentable/versionedconfig/GitProperties.java
@@ -31,7 +31,7 @@ public class GitProperties {
     private final Path localRepository;
     private final String branch;
 
-    private final int timeoutInSec;
+    private final int duration;
 
     public GitProperties(URI remoteRepository,
                          @Nullable Path localRepository,
@@ -45,22 +45,22 @@ public class GitProperties {
         this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
         this.localRepository = localRepository;
         this.branch = branch;
-        this.timeoutInSec = -1;
+        this.duration = -1;
     }
 
     /*
      * Isolate new timeout feature into own constructor for now.
      * Dependent services will override bean defaultVersioningServiceProperties
-     * to initialize this constructor and set timeout as needed.
+     * to initialize this constructor and set duration (timeout) as needed.
      */
     public GitProperties(List<URI> remoteRepositories,
                          @Nullable Path localRepository,
                          String branch,
-                         int timeoutInSec){
+                         int duration){
         this.remoteRepositories = ImmutableList.copyOf(remoteRepositories);
         this.localRepository = localRepository;
         this.branch = branch;
-        this.timeoutInSec = timeoutInSec;
+        this.duration = duration;
     }
 
     public List<URI> getRemoteRepositories() {
@@ -75,7 +75,7 @@ public class GitProperties {
         return branch;
     }
 
-    public int getTimeoutInSec() { return timeoutInSec; }
+    public int getDuration() { return duration; }
 
     @Override
     public boolean equals(Object o) {
@@ -90,12 +90,12 @@ public class GitProperties {
         return Objects.equal(remoteRepositories, that.remoteRepositories) &&
                 Objects.equal(localRepository, that.localRepository) &&
                 Objects.equal(branch, that.branch) &&
-                Objects.equal(timeoutInSec, that.timeoutInSec);
+                Objects.equal(duration, that.duration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(remoteRepositories, localRepository, branch, timeoutInSec);
+        return Objects.hashCode(remoteRepositories, localRepository, branch, duration);
     }
 
     @Override
@@ -104,7 +104,7 @@ public class GitProperties {
                 "remoteRepositories=" + remoteRepositories +
                 ", localRepository=" + localRepository +
                 ", branch='" + branch + '\'' +
-                ", timeoutInSec=" + timeoutInSec +
+                ", duration=" + duration +
                 '}';
     }
 }

--- a/src/main/java/com/opentable/versionedconfig/GitProperties.java
+++ b/src/main/java/com/opentable/versionedconfig/GitProperties.java
@@ -48,6 +48,11 @@ public class GitProperties {
         this.timeoutInSec = -1;
     }
 
+    /*
+     * Isolate new timeout feature into own constructor for now.
+     * Dependent services will override bean defaultVersioningServiceProperties
+     * to initialize this constructor and set timeout as needed.
+     */
     public GitProperties(List<URI> remoteRepositories,
                          @Nullable Path localRepository,
                          String branch,


### PR DESCRIPTION
Recently, we have been looking into a "stale configuration" bug in gateway-guestcenter.  Cause of this is that the scheduled task responsible for syncing with github hangs and never exists leading to a few instance's config file to become stale. The theory was that some jGit command was stuck causing the task to hang. By enabling and adding more logs, we were able to pinpoint to the location where a jgit command is executed but never returned. I wrote a more elaborate explanation here - 

https://docs.google.com/document/d/18jckj-kRzMGJAOhH_B2Xdunk-Cvr8kzyx3TAO1VLpiY/edit?usp=sharing

The propose solution was to modify otj-version-config (the library that uses jgit) to set some timeout value on the jgit command that hangs.